### PR TITLE
Remove `is_null`

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -11,6 +11,7 @@ class Config extends \PhpCsFixer\Config
 		'braces' => false,
 		'new_with_braces' => false,
 		'indentation_type' => true,
+		'is_null' => false,
 	];
 
 	protected $indent = "\t";


### PR DESCRIPTION
According to latest benchmarks

- https://www.php.net/manual/en/function.is-null.php
- https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/4015

there is no performance advantage in using `null === $var` or `$var === null` over `is_null($var)`. In fact `is_null($var)` is marginally faster since PHP 7.0 and actually faster (but not by a lot) since PHP 7.3.

As the historical reason for this rule is gone, I propose to remove it from our config and let the developers choose the syntax that they find more readable.

P.S. There is a performance caveat that `is_null($var)` in a namespace might be slower because of the time spent resolving it, but it is solved as we already have a rule `native_function_invocation` that changes `is_null($var)` to `\is_null($var)`.