### PR TITLE
Add migration rulesets

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -19,6 +19,10 @@ class Config extends \PhpCsFixer\Config
 		'modernize_strpos' => false,
 		'use_arrow_functions' => false,
 		'declare_strict_types' => false,
+		'method_argument_space' => [
+			'after_heredoc' => true,
+			'on_multiline' => 'ignore',
+		],
 
 		// Overrides `PHP80Migration:risky` and `@Symfony:risky`
 		'no_php4_constructor' => false,

--- a/src/Config.php
+++ b/src/Config.php
@@ -5,8 +5,25 @@ namespace JanaSeta\PhpCs;
 class Config extends \PhpCsFixer\Config
 {
 	protected array $rules = [
+		// Pre-made rulesets
 		'@Symfony:risky' => true,
-		'ternary_to_null_coalescing' => true,
+		'@PHP80Migration' => true,
+		'@PHP80Migration:risky' => true,
+
+		// Overrides `@PHP80Migration`
+		'assign_null_coalescing_to_coalesce_equal' => false,
+		'heredoc_indentation' => false,
+
+		// Overrides `@PHP80Migration:risky`
+		'get_class_to_class_keyword' => false,
+		'modernize_strpos' => false,
+		'use_arrow_functions' => false,
+		'declare_strict_types' => false,
+
+		// Overrides `PHP80Migration:risky` and `@Symfony:risky`
+		'no_php4_constructor' => false,
+
+		// Our custom rules
 		'phpdoc_align' => false,
 		'braces' => false,
 		'new_with_braces' => false,


### PR DESCRIPTION
The migration rulesets include rules that increase code compatibility with newer PHP versions as well as take advantage of new features. This PR adds these rulesets in a (mostly) backwards compatible manner to prepare code for new PHP versions but not break it for older PHPs up to PHP 7.1.

This is be useful for preparing older projects for newer PHP versions as well as encouraging up-to-date practices. I will discuss the rules themselves in separate comments in this thread.

## Changes and non-changes

We already have `@Symfony:risky` that includes `pow_to_exponentiation`, `combine_nested_dirname`, `implode_call`, `no_alias_functions`, `no_unneeded_final_method`, `no_unreachable_default_argument_value` and `non_printable_character` so these would not be changes.

We already had `ternary_to_null_coalescing` in our rules. This PR removes it from the explicit list as it's included via `@PHP80Migration`.

Ruleset `@Symfony:risky` also includes `no_php4_constructor` but this PR suggests to turn it off.

Unrelated to the main point, this also adds some comments to our rule list to highlight overrides.

## Discuss

Besides deciding whether we need this at all, we should also consider if 7.3 (or even 7.4) support should be removed or if, on the other hand, we need to keep support for 7.0 or older PHPs in these defaults.