### PR TITLE
Remove `void_return`

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -23,6 +23,7 @@ class Config extends \PhpCsFixer\Config
 			'after_heredoc' => true,
 			'on_multiline' => 'ignore',
 		],
+		'void_return' => false,
 
 		// Overrides `PHP80Migration:risky` and `@Symfony:risky`
 		'no_php4_constructor' => false,


### PR DESCRIPTION
Trying out the new rulesets on existing projects, I noticed that the `void_return` rule brings in a huge amount of changes in tests, but all those changes seem insignificant.

Here's an example:

```php
public function testRedirect()
{
	$provider = Mockery::mock(Saml2\Provider::class, function(MockInterface $mock) use ($redirect) {
		// ...
	});

	// ...
}
```
is changed to
```php
public function testRedirect(): void
{
	$provider = Mockery::mock(Saml2\Provider::class, function(MockInterface $mock) use ($redirect): void {
		// ...
	});

	// ...
}
```

I'm not sure if we want to add `: void` to every test and every callback. I didn't have a lot of such changes in actual business code or other files.