### PR TITLE
Add PHP81 and PHP82 migration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "php": "^7.1 || ^8.0",
+        "php": "^8.1",
         "friendsofphp/php-cs-fixer": "^3.0"
     },
     "autoload": {

--- a/src/Config.php
+++ b/src/Config.php
@@ -7,10 +7,10 @@ class Config extends \PhpCsFixer\Config
 	protected array $rules = [
 		// Pre-made rulesets
 		'@Symfony:risky' => true,
-		'@PHP80Migration' => true,
+		'@PHP82Migration' => true,
 		'@PHP80Migration:risky' => true,
 
-		// Overrides `@PHP80Migration`
+		// Overrides `@PHP82Migration`
 		'assign_null_coalescing_to_coalesce_equal' => false,
 		'heredoc_indentation' => false,
 


### PR DESCRIPTION
Switching `@PHP80Migration` ruleset to `@PHP82Migration`.

[PHP81 migration](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/master/doc/ruleSets/PHP81Migration.rst) changes the octal notation from `0123` to `0o123`. It's not compatible with PHP 8.0, but the PHP 8.0 active support is over.

[PHP82 migration](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/master/doc/ruleSets/PHP82Migration.rst) only changes `${var}` to `{$var}` within string interpolation. Both syntaxes are valid in older PHP versions, so this rule is safe to add even if not requiring PHP 8.2.

Ruleset `@PHP80Migration:risky` stays as is, there are no new iterations to it.

With this we are also dropping the support for older (7.1–8.0) PHP versions for this and future iterations of our CS fixer config.

Reolves #4